### PR TITLE
Fixed calls to be compatible with newer openssl versions

### DIFF
--- a/include/nfc3d/drbg.h
+++ b/include/nfc3d/drbg.h
@@ -31,7 +31,7 @@
 #define NFC3D_DRBG_OUTPUT_SIZE		32	/* Every iteration generates 32 bytes */
 
 typedef struct {
-	HMAC_CTX hmacCtx;
+	HMAC_CTX *hmacCtx;
 	bool used;
 	uint16_t iteration;
 

--- a/src/drbg.c
+++ b/src/drbg.c
@@ -40,8 +40,8 @@ void nfc3d_drbg_init(nfc3d_drbg_ctx * ctx, const uint8_t * hmacKey, size_t hmacK
 	memcpy(ctx->buffer + sizeof(uint16_t), seed, seedSize);
 
 	// Initialize underlying HMAC context
-	HMAC_CTX_init(&ctx->hmacCtx);
-	HMAC_Init_ex(&ctx->hmacCtx, hmacKey, hmacKeySize, EVP_sha256(), NULL);
+	ctx->hmacCtx = HMAC_CTX_new();
+	HMAC_Init_ex(ctx->hmacCtx, hmacKey, hmacKeySize, EVP_sha256(), NULL);
 }
 
 void nfc3d_drbg_step(nfc3d_drbg_ctx * ctx, uint8_t * output) {
@@ -50,7 +50,7 @@ void nfc3d_drbg_step(nfc3d_drbg_ctx * ctx, uint8_t * output) {
 
 	if (ctx->used) {
 		// If used at least once, reinitialize the HMAC
-		HMAC_Init_ex(&ctx->hmacCtx, NULL, 0, NULL, NULL);
+		HMAC_Init_ex(ctx->hmacCtx, NULL, 0, NULL, NULL);
 	} else {
 		ctx->used = true;
 	}
@@ -61,13 +61,13 @@ void nfc3d_drbg_step(nfc3d_drbg_ctx * ctx, uint8_t * output) {
 	ctx->iteration++;
 
 	// Do HMAC magic
-	HMAC_Update(&ctx->hmacCtx, ctx->buffer, ctx->bufferSize);
-	HMAC_Final(&ctx->hmacCtx, output, NULL);
+	HMAC_Update(ctx->hmacCtx, ctx->buffer, ctx->bufferSize);
+	HMAC_Final(ctx->hmacCtx, output, NULL);
 }
 
 void nfc3d_drbg_cleanup(nfc3d_drbg_ctx * ctx) {
 	assert(ctx != NULL);
-	HMAC_CTX_cleanup(&ctx->hmacCtx);
+	HMAC_CTX_free(ctx->hmacCtx);
 }
 
 void nfc3d_drbg_generate_bytes(const uint8_t * hmacKey, size_t hmacKeySize, const uint8_t * seed, size_t seedSize, uint8_t * output, size_t outputSize) {

--- a/src/util.c
+++ b/src/util.c
@@ -26,14 +26,14 @@
 #include <stdint.h>
 
 void aes128ctr(const uint8_t * in, uint8_t * out, size_t size, const uint8_t * key, const uint8_t * iv) {
-	EVP_CIPHER_CTX ctx;
+	EVP_CIPHER_CTX* ctx = EVP_CIPHER_CTX_new();
 	int pos;
 
-	EVP_CIPHER_CTX_init(&ctx);
-	EVP_EncryptInit_ex(&ctx, EVP_aes_128_ctr(), NULL, key, iv);
-	EVP_EncryptUpdate(&ctx, out, &pos, in, size);
-	EVP_EncryptFinal_ex(&ctx, out + pos, &pos);
-	EVP_CIPHER_CTX_cleanup(&ctx);
+	EVP_CIPHER_CTX_init(ctx);
+	EVP_EncryptInit_ex(ctx, EVP_aes_128_ctr(), NULL, key, iv);
+	EVP_EncryptUpdate(ctx, out, &pos, in, size);
+	EVP_EncryptFinal_ex(ctx, out + pos, &pos);
+	EVP_CIPHER_CTX_cleanup(ctx);
 }
 
 void sha256hmac(const uint8_t * key, size_t keySize, const uint8_t * in, size_t inSize, uint8_t * out) {


### PR DESCRIPTION
amiitool would not compile with OpenSSL 1.1.1c (it uses some deprecated openssl functions), so I fixed them according to the documentation until it compiled.

This is untested (turns out I didn't need amiitool) but I didn't want the effort to go to waste :-)